### PR TITLE
feat: add interop with EX mod

### DIFF
--- a/FortEntrance.cs
+++ b/FortEntrance.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using ArcherLoaderMod.Source.ModImport;
 using FortRise;
 using HarmonyLib;
 using Monocle;
@@ -8,7 +7,7 @@ using TowerFall;
 
 namespace ArcherLoaderMod
 {
-    
+
     [Fort("com.reddude.archerLoader", "archer Loader")]
     public class FortEntrance : FortModule
     {
@@ -20,7 +19,7 @@ namespace ArcherLoaderMod
         }
 
         public override Type SettingsType => typeof(ArcherLoaderSettings);
-        public static ArcherLoaderSettings Settings => (ArcherLoaderSettings) Instance.InternalSettings;
+        public static ArcherLoaderSettings Settings => (ArcherLoaderSettings)Instance.InternalSettings;
 
         public override void LoadContent()
         {
@@ -33,12 +32,13 @@ namespace ArcherLoaderMod
             harmony.PatchAll(typeof(FortEntrance).Assembly);
             Mod.Load();
             //Settings.FlightTest = () => { Music.Play("Flight"); };
-     
+
             //PinkSlime.LoadPatch();
             //TriggerBrambleArrow.Load();
             //PatchEnemyBramble.Load();
 
             typeof(ModExports).ModInterop();
+            FortRise.RiseCore.Events.OnPreInitialize += OnPreInitialize;
         }
 
         public override void Unload()
@@ -50,38 +50,43 @@ namespace ArcherLoaderMod
         {
             Mod.OnVariantsRegister(variants, noPerPlayer);
         }
+
+        private void OnPreInitialize()
+        {
+            TfExAPIModImport.MarkModuleAsSafe?.Invoke(this);
+        }
     }
 
-// Harmony can be supported
+    // Harmony can be supported
 
-//[HarmonyPatch(typeof(MainMenu), "BoolToString")]
-//public class MyPatcher
-//{
-//    static void Postfix(ref string __result)
-//    {
-//        if (__result == "ON")
-//        {
-//            __result = "ENABLED";
-//            return;
-//        }
+    //[HarmonyPatch(typeof(MainMenu), "BoolToString")]
+    //public class MyPatcher
+    //{
+    //    static void Postfix(ref string __result)
+    //    {
+    //        if (__result == "ON")
+    //        {
+    //            __result = "ENABLED";
+    //            return;
+    //        }
 
-//        __result = "DISABLED";
-//    }
-//}
+    //        __result = "DISABLED";
+    //    }
+    //}
 
 
-/* 
-Example of interppting with libraries
-Learn more: https://github.com/MonoMod/MonoMod/blob/master/README-ModInterop.md
-*/
+    /* 
+    Example of interppting with libraries
+    Learn more: https://github.com/MonoMod/MonoMod/blob/master/README-ModInterop.md
+    */
 
-[ModExportName("CustomArcherLoaderModExport")]
-public static class ModExports
-{
-    public static Dictionary<ArcherData, ArcherCustomData> GetArcherCustomDataDict() => Mod.ArcherCustomDataDict;
-    public static List<Atlas> GetCustomAtlasList() => Mod.customAtlasList;
-    public static List<SpriteData> GetCustomSpriteDataList() => Mod.customSpriteDataList;
-    public static List<CharacterSounds> GetCustomSFXList() => Mod.customSFXList;
-}
+    [ModExportName("CustomArcherLoaderModExport")]
+    public static class ModExports
+    {
+        public static Dictionary<ArcherData, ArcherCustomData> GetArcherCustomDataDict() => Mod.ArcherCustomDataDict;
+        public static List<Atlas> GetCustomAtlasList() => Mod.customAtlasList;
+        public static List<SpriteData> GetCustomSpriteDataList() => Mod.customSpriteDataList;
+        public static List<CharacterSounds> GetCustomSFXList() => Mod.customSFXList;
+    }
 
 }

--- a/Source/ModImport/TfExAPIModImport.cs
+++ b/Source/ModImport/TfExAPIModImport.cs
@@ -1,0 +1,16 @@
+﻿using FortRise;
+using MonoMod.ModInterop;
+
+namespace ArcherLoaderMod.Source.ModImport
+{
+    [ModImportName("TF.EX.API")]
+    public class TfExAPIModImport
+    {
+        public static Action<FortModule> MarkModuleAsSafe;
+
+        static TfExAPIModImport()
+        {
+            typeof(TfExAPIModImport).ModInterop();
+        }
+    }
+}


### PR DESCRIPTION
This PR mark ArcherLoader as safe using [EX mod](https://github.com/Fcornaire/TF.EX). It mostly prevent the user showing this when only using EX and ArcherLoader mod

![image](https://github.com/RedDude/ArcherLoader/assets/14372342/dd9fe6f9-85b9-44c4-be6e-bfd7f1349e3e)

EX expose some [API](https://github.com/Fcornaire/TF.EX/blob/main/EX-API.md)  functions, especially one to tell when a mod is safe.
ArcherLoader is only doing cosmetics + i did made some test with it , everything was ok

Note: there is one thing i didn't tested because i'm unable to trigger self kill 😅 (i tried arrow + right stick to the left , but no success)