### PR TITLE
Upgrade mod to FortRise v5.0

### DIFF
--- a/Mod.cs
+++ b/Mod.cs
@@ -145,10 +145,13 @@ namespace ArcherLoaderMod
         public static void LoadArcherContents()
         {
             allCustomArchers.AddRange(LoadContentAtPath($"{Calc.LOADPATH}{_contentCustomArchersPath}", ContentAccess.Content));
-            var contentPath = Content.GetContentPath("");
-            allCustomArchers.AddRange(LoadContentAtPath(contentPath+$"/{_customArchersPath}", ContentAccess.ModContent));
             allCustomArchers.AddRange(LoadContentAtPath($"{_customArchersPath}", ContentAccess.Root));
-            allCustomArchers.AddRange(LoadContentAtPath(contentPath.Replace("/Content", "")+$"/{_customArchersPath}", ContentAccess.Root));
+
+            // We need to think a better solution than loading content at random location
+
+            // var contentPath = Content.GetContentPath("");
+            // allCustomArchers.AddRange(LoadContentAtPath(contentPath+$"/{_customArchersPath}", ContentAccess.ModContent));
+            // allCustomArchers.AddRange(LoadContentAtPath(contentPath.Replace("/Content", "")+$"/{_customArchersPath}", ContentAccess.Root));
             // allCustomArchers.AddRange(LoadContentAtPath(Content.GetContentPath("").Replace("/Content", ""), ContentAccess.Root));
         }
         
@@ -413,11 +416,10 @@ namespace ArcherLoaderMod
 
             var archerName = directory.Split(Convert.ToChar(_separator)).Last();
             var path = $"{directory}{_separator}".Replace($"Content{_separator}", $"");
-            var pathModContentFolder = false;
             if (contentAccess == ContentAccess.ModContent) 
             {
-                path = path.Replace(Content.GetContentPath(), "");
-                path = Content.GetContentPath() + path;
+                // path = path.Replace(Content.GetContentPath(), "");
+                // path = Content.GetContentPath() + path;
                 contentAccess = ContentAccess.Root;
             }
 
@@ -427,7 +429,7 @@ namespace ArcherLoaderMod
             Atlas atlas = null;
             if (File.Exists($"{pathWithContentPrefix}atlas.xml") && File.Exists($"{pathWithContentPrefix}atlas.png"))
             {
-                atlas = content.CreateAtlas($"{path}atlas.xml", $"{path}atlas.png", true, contentAccess);
+                atlas = AtlasExt.CreateAtlas(content, $"{path}atlas.xml", $"{path}atlas.png", contentAccess);
                 customAtlasList.Add(atlas);
             }
             
@@ -472,7 +474,7 @@ namespace ArcherLoaderMod
             if (File.Exists($"{pathWithContentPrefix}menuAtlas.xml") &&
                 File.Exists($"{pathWithContentPrefix}menuAtlas.png"))
             {
-                atlasArcherMenu = content.CreateAtlas($"{path}menuAtlas.xml", $"{path}menuAtlas.png", true, contentAccess);
+                atlasArcherMenu = AtlasExt.CreateAtlas(content, $"{path}menuAtlas.xml", $"{path}menuAtlas.png", contentAccess);
                 customAtlasList.Add(atlasArcherMenu);
                 spriteDataMenu = content.CreateSpriteData($"{path}menuSpriteData.xml", atlasArcherMenu, contentAccess);
                 customSpriteDataList.Add(spriteDataMenu);

--- a/meta.json
+++ b/meta.json
@@ -1,7 +1,13 @@
 {
 	"name": "Archer Loader",
-	"version": "1.3.1",
+	"version": "2.0.0",
 	"author": "RedDude",
 	"description": "Load Custom Archers easily by just Drag n Drop. Create Archers with custom hair, wings, ghost, particles, layers, skins and even taunts for archers",
-	"dll": "ArcherLoaderMod.dll"
+	"dll": "ArcherLoaderMod.dll",
+	"dependencies": [
+		{
+			"name": "FortRise",
+			"version": "5.0.0"
+		}
+	]
 }

--- a/meta.json
+++ b/meta.json
@@ -1,5 +1,5 @@
 {
-	"name": "Archer Loader",
+	"name": "ArcherLoader",
 	"version": "2.0.0",
 	"author": "RedDude",
 	"description": "Load Custom Archers easily by just Drag n Drop. Create Archers with custom hair, wings, ghost, particles, layers, skins and even taunts for archers",

--- a/meta.json
+++ b/meta.json
@@ -9,5 +9,11 @@
 			"name": "FortRise",
 			"version": "5.0.0"
 		}
-	]
+	],
+	"update": {
+		"github": {
+			"repository": "RedDude/ArcherLoader",
+			"tagRegex": "v(.*)"
+		}
+	}
 }


### PR DESCRIPTION
This PR will upgrade ArcherLoader to v5.0.

There's some caveats on upgrading, like inability to get a content path from a mod which disables an ability to load outside of root and inside of mod content. While it seems kinda bad, I also discourage from loading content directly with a `System.IO` anyway since you cannot access them with zip files.

The `Content/Mod/CustomArchers` still works fine which most users put their archers anyway and that's the only important bits when it comes to upgrading the mod.